### PR TITLE
Drop Codecov token

### DIFF
--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -46,8 +46,6 @@ test_task:
       image: ruby:2.7
       image: ruby:3.0
   <<: *bundle_cache
-  environment:
-    CODECOV_TOKEN: ENCRYPTED[b82868a5d8629f13ace2b788610b00a8beb6336bc8c5d81ea866b681c3f5c174460bcdbe5d5de9efced470b0d5981b32]
   test_script: bundle exec rspec
   only_if: ($CIRRUS_BRANCH == 'master') ||
     changesInclude(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require 'pry-byebug'
 require 'simplecov'
 SimpleCov.start
 
-if ENV['CODECOV_TOKEN']
+if ENV['CI']
   require 'codecov'
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end


### PR DESCRIPTION
They wrote it's no more necessary for Cirrus CI:
https://community.codecov.io/t/add-support-of-uploading-from-cirrus-ci-without-token/1028/16